### PR TITLE
Respect skip_render config and run criticalcss in succession.

### DIFF
--- a/lib/critical-css.js
+++ b/lib/critical-css.js
@@ -165,15 +165,15 @@ function CriticalCssWorker() {
     });
     var htmlFiles = notSkipRenderFiles.filter(isHtmlFile);
 
-    var promises = [];
-
-    htmlFiles.forEach(function(htmlFile) {
-      var criticalPromise = applyCriticalToFile(publicDir, htmlFile, options, log);
-
-      promises.push(criticalPromise);
-    });
-
-    return Promise.all(promises).then(function(resolvedPromises) {
+    return new Promise(function(resolve, reject) {
+      htmlFiles.reduce(function(promise, htmlFile) {
+        return promise.then(function() {
+          return applyCriticalToFile(publicDir, htmlFile, options, log);
+        });
+      }, Promise.resolve()).then(function() {
+        resolve();
+      });
+    }).then(function(resolvedPromises) {
       log.log('Finished including all critical css into the html files');
       return resolvedPromises;
     });

--- a/lib/critical-css.js
+++ b/lib/critical-css.js
@@ -7,6 +7,7 @@ var Critical = require('critical');
 var fs = require('hexo-fs');
 var pathFn = require('path');
 var assign = require('object-assign');
+var minimatch = require('minimatch');
 
 /**
  * @parameter {boolean} needWorker is it necessary to register the worker
@@ -26,6 +27,22 @@ function isHtmlFile(candidateName) {
   var extention =  extname[0] === '.' ? extname.slice(1) : extname;
 
   return extention === 'html' || extention === 'htm';
+}
+
+/**
+ * If candidateName matches any glob filters
+ *
+ * @param  {string} candidateName the filename to assess
+ * @param  {[type]} filters paths to filter against
+ *
+ * @return {boolean} false if the filename does not matched
+ */
+function filterFiles(candidateName, filters) {
+  filters = filters || [];
+
+  return filters.reduce(function(prev, filter) {
+    return prev && !minimatch(candidateName, filter);
+  }, true);
 }
 
 /**
@@ -126,10 +143,11 @@ function applyCriticalToFile(publicDir, htmlFile, options, log) {
  *                   to each HTML file.
  */
 function CriticalCssWorker() {
-  var log = this.log;
-  var options = this.config.criticalcss;
-  var publicDir = this.public_dir;
-  var renderer = this.extend.renderer;
+  var hexo = this;
+  var log = hexo.log;
+  var options = hexo.config.criticalcss;
+  var publicDir = hexo.public_dir;
+  var renderer = hexo.extend.renderer;
 
   if (!options.enable) {
     return Promise.all([]);
@@ -142,7 +160,10 @@ function CriticalCssWorker() {
     }
 
     var files = fs.listDirSync(publicDir);
-    var htmlFiles = files.filter(isHtmlFile);
+    var notSkipRenderFiles = files.filter(function(file) {
+      return filterFiles(file, hexo.config.skip_render);
+    });
+    var htmlFiles = notSkipRenderFiles.filter(isHtmlFile);
 
     var promises = [];
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "critical": "^0.7.2",
     "hexo-fs": "^0.1.5",
+    "minimatch": "^3.0.0",
     "object-assign": "^4.0.1",
     "path": "^0.12.7"
   }


### PR DESCRIPTION
- Use minimatch to filter out skip_render files.
- Make criticalcss run sequentially instead of in parallel as it seems to fail when dealing with multiple files in parallel.
