### PR TITLE
Locate base and src options for Critical CSS

### DIFF
--- a/lib/critical-css.js
+++ b/lib/critical-css.js
@@ -72,11 +72,18 @@ function filterFiles(candidateName, candidateFilters) {
  * @return {object} the options for critical.generate
  */
 function getCriticalOptions(publicDir, htmlFile, options, log) {
+  // join publicDir and htmlFile to get absolute file path
+  var src = pathFn.normalize(pathFn.join(publicDir, htmlFile));
+
+  // remove file name from absolute file path to get
+  // base directory
+  var base = src.replace(pathFn.basename(src), '');
+
   var criticalOptions = assign(
     options.critical,
     {
-      base: publicDir,
-      src: htmlFile
+      base: base,
+      src: src
     }
   );
 

--- a/lib/critical-css.js
+++ b/lib/critical-css.js
@@ -111,6 +111,10 @@ function applyCriticalToFile(publicDir, htmlFile, options, log) {
       log.log('Generated critical CSS for', htmlFile);
 
       return;
+    })
+    .catch(function(error) {
+      log.error('Unable to inline critical CSS for', htmlFile);
+      log.error(error);
     });
   }
 
@@ -148,6 +152,10 @@ function applyCriticalToFile(publicDir, htmlFile, options, log) {
     log.error('The HTML expression hexo-critical-css is attempting to replace is not present in the HTML for file', htmlFile, ': the match was', options.htmlTagToReplace);
 
     return;
+  })
+  .catch(function(error) {
+    log.error('Unable to generate critical CSS for', htmlFile);
+    log.error(error);
   });
 }
 


### PR DESCRIPTION
I was having issues with this plugin because Critical CSS couldn't correctly locate the CSS file to operate on. It's possible I missed an option setting, and I apologize in advance if so ...

Using the regular [css template helper](https://hexo.io/docs/helpers.html#css), the CSS path generated by Hexo in my HTML files could be `css/styles.css`, `../css/styles.css`, `../../css/styles.css`, etc. 

However, as written, this plugin always treats the [`base`](https://github.com/addyosmani/critical#options) option for Critical CSS as the joining of `publicDir` and the CSS path generated by Hexo. Thus, Critical CSS always found the CSS file for the homepage `public/index.html`, but for any posts, pages, category list page, or tag list page, Critical CSS could not locate the CSS file. 

For example:
1. For the homepage: `publicDir` = `~/hexo/public/` and the CSS file path from Hexo is `css/style.css`. Thus combining to form the `base` option at the correct location: `~/hexo/public/css/style.css`.
2. For a post: `publicDir` =  `~/hexo/public/` (same for every page) and the CSS file path from Hexo is `../css/style.css`. Thus combining to form the `base` option at the wrong location: `~/hexo/css/style.css`.

Note that I can successfully by pass this error by manually including CSS files instead of using Hexo's css template helper function, but I wanted to use native Hexo helpers where possible.

The solution (for me) was to create Critical CSS's `src` option by joining the `publicDir` and `htmlFile` paths given to [`getCriticalOptions`](https://github.com/john-whitley/hexo-critical-css/commit/d4b7ff9a339939d63f573bfafe9ec05f9a448810#diff-938103dc285624daee0885b6d9d4e4fcR76). Then, [lop off the file name from the path](https://github.com/john-whitley/hexo-critical-css/commit/d4b7ff9a339939d63f573bfafe9ec05f9a448810#diff-938103dc285624daee0885b6d9d4e4fcR80) to create Critical CSS's `base` option. As a result, `src` is always relative to the file Hexo is currently processing, and I can use Hexo's css template helper.

Lastly, I [caught errors from Critical CSS generate()](https://github.com/john-whitley/hexo-critical-css/commit/a2ead55f4072ad08f62281e5f3c7c073fb8df5e9#diff-938103dc285624daee0885b6d9d4e4fc) so they could be printed to the log for easier debugging.